### PR TITLE
Add announcement of ReproHackathon 3

### DIFF
--- a/docs/hackathon_3.md
+++ b/docs/hackathon_3.md
@@ -1,0 +1,33 @@
+# ReproHackathon-3, 25-27 novembre 2019
+
+## Analyse de phénotypage à partir d'images issues d'une plateforme de phéotypage haut-débit de plantes.
+
+### Introduction
+
+Dans cette troisième édition du reprohackathon, nous partirons de l'étude de Artzet et al. [1] dans laquelle les auteurs reconstruisent automatiquement la structure des plantes à partir d'images multi-vues.
+
+Les différentes étapes de la chaine de traitement sont:
+
+- binarisation des images (identification des pixels de plantes vs cabine)
+- recontruction 3D mutli-vues (calcul du volume de la plante à partir des images segméntées)
+- squeletisation (calcul du squelette de la plante)
+- ségmentation en organe (identification et labellisation des différents organes de la plante)
+
+
+### Objectif
+
+Les algorithmes des différentes étapes sont disponibles à partir de la bibliothèque Python **Phenomenal** :
+
+  - Documentation : https://phenomenal.readthedocs.io
+  - Code source : https://github.com/openalea/phenomenal.
+
+
+Des notebooks Jupiter, illustrant les différentes étapes, sont disponibles dans le repertoire examples.
+
+
+## Références
+* [1] [Artzet et al. (bioarxiv, 2019)](https://github.com/openalea/phenomenal)
+
+*Cette troisième édition des ReproHackathons est soutenue par le [GDR MaDICS](https://www.madics.fr), le [GDR BIM](http://www.gdr-bim.cnrs.fr) et par l'[Institut Français de Bioinformatique](http://www.france-bioinformatique.fr).*
+
+![MaDICS](https://ifb-elixirfr.github.io/ReproHackathon/logo-madics.png) ![BIM](https://ifb-elixirfr.github.io/ReproHackathon/logo-gdrbim-web.jpg) ![IFB](https://ifb-elixirfr.github.io/ReproHackathon/logo-ifb.png)

--- a/docs/hackathon_3_programme.md
+++ b/docs/hackathon_3_programme.md
@@ -1,0 +1,45 @@
+# ReproHackathon-3
+
+**25-26 novembre 2019**
+
+La troisième édition des [ReproHackathons](index.md) se tiendra au Cirad, [Lavalette](https://http://cartes.cirad.fr//) à Montpellier.
+
+## Cas d'usage
+
+[Analyse d'images de phénotypage haut-débit de plantes](hackathon_3.md)
+
+## Programme (provisoire)
+
+### 25 novembre 2019
+
+12h00 Accueil
+
+* 12h00-1300 : Présentation des use cases et du cloud de l'IFB
+* 1300-14h00 : *Pause déjeuner*
+* 14h00-15h00 : Présentation des use cases et du cloud de l’IFB
+* 15h00-17h30 : Phase 1 hackathon
+* 17h30-18h00 : Rapport d’avancement : tâches effectuées, difficultés rencontrées
+
+### 26 novembre 2019
+
+9h00 Accueil
+
+* 9h00-12h00 : Phase 2 hackathon
+* 12h00–12h30 : Rapport d’avancement
+* 12h30-13h30 : Pause déjeuner
+* 13h30-16h30 : Phase finale hackathon
+* 16h30-17h30 : Rapport final, conclusions
+
+## Inscriptions
+
+Les inscriptions se font via [ce formulaire](http://www.madics.fr/manifestations/organisation/inscription/?manif=1567779026.5358).
+
+## Resultats
+
+Les sources des workflows développés et les résultats seront disponibles sur le [dépôt github](https://github.com/IFB-ElixirFr/ReproHackathon/tree/master/reprohackathon3).
+
+
+*La troisième édition des ReproHackathons est soutenue par le [GDR MaDICS](https://www.madics.fr), le [GDR BIM](http://www.gdr-bim.cnrs.fr) et par l'[Institut Français de Bioinformatique](http://www.france-bioinformatique.fr).*
+
+![MaDICS](https://ifb-elixirfr.github.io/ReproHackathon/logo-madics.png) ![BIM](https://ifb-elixirfr.github.io/ReproHackathon/logo-gdrbim-web.jpg) ![IFB](https://ifb-elixirfr.github.io/ReproHackathon/logo-ifb.png)
+

--- a/docs/index-en.md
+++ b/docs/index-en.md
@@ -1,25 +1,25 @@
 *\[[fr](index.md)\] en*
 
-Due to the availability of multiple and large-scale datasets, diverse and complex data analysis tools and pipelines, reproducing computational experiments is becoming more and more challenging [[Alsheikh-Ali *et al*. 2011](https://doi.org/10.1371%2Fjournal.pone.0024357), [Nekrutenko & Taylor, 2012](https://doi.org/10.1038%2Fnrg3305)]. 
+Due to the availability of multiple and large-scale datasets, diverse and complex data analysis tools and pipelines, reproducing computational experiments is becoming more and more challenging [[Alsheikh-Ali *et al*. 2011](https://doi.org/10.1371%2Fjournal.pone.0024357), [Nekrutenko & Taylor, 2012](https://doi.org/10.1038%2Fnrg3305)].
 
-[ReProVirtuFlow](https://www.madics.fr/actions/actions-en-cours/reprovirtuflow) is a research group from [GDR MaDICS](https://www.madics.fr) aiming at providing a state-of-the-art on reproducibility-oriented approaches considering as promising directions (i) scientific workflows (ii) provenance, and (iii) virtualized computing environments (virtual machines and containers). Technical coordinators of data analysis and management facilities (CNRS INSB and IN2P3) as well as experts in computer science form part of the ReProVirtuFlow consortium. 
+[ReProVirtuFlow](https://www.madics.fr/actions/actions-en-cours/reprovirtuflow) is a research group from [GDR MaDICS](https://www.madics.fr) aiming at providing a state-of-the-art on reproducibility-oriented approaches considering as promising directions (i) scientific workflows (ii) provenance, and (iii) virtualized computing environments (virtual machines and containers). Technical coordinators of data analysis and management facilities (CNRS INSB and IN2P3) as well as experts in computer science form part of the ReProVirtuFlow consortium.
 
 # ReproHackathons
-As part of our activities, we are organizing reproducibility-oriented hackathons aimed at testing workflow management systems in realistic conditions to reproduce scientific experiments.  
+As part of our activities, we are organizing reproducibility-oriented hackathons aimed at testing workflow management systems in realistic conditions to reproduce scientific experiments.
 
-Each ReproHackathon will provide to participants : 
+Each ReproHackathon will provide to participants :
 * access to the [IFB Cloud infrastructure](http://www.france-bioinformatique.fr/en/cloud),
 * use cases based on academic papers: for each use case, an input dataset as well as a data analysis pipeline will be provided . The challenge will consist in reproducing the published results.
 
-Participants are encouraged to form teams and select 
+Participants are encouraged to form teams and select
 * one of the proposed use cases ;
-* a workflow management system to implement the data analysis pipeline and try to obtain the expected results. 
+* a workflow management system to implement the data analysis pipeline and try to obtain the expected results.
 
 ## ReproHackathons Series
 
 * [First edition](hackathon_1_programme.md), 1-2 June 2017, IFB-core, Campus CNRS, Gif-sur-Yvette
 * [Second edition](hackathon_2_programme.md), 9-10 July 2018, LBBE-PRABI, Campus LyonTech-la Doua, Lyon
-* Third edition, 25-26 November 2019, Montpellier
+* [Third edition](hackathon_3_programme.md), 25-26 November 2019, Montpellier
 
 ## Steering Committee
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@
 Face aux masses de données disponibles, à la multitude d’outils existants et au caractère complexe des protocoles d’analyse de données scientifiques, reproduire une expérience est particulièrement difficile, comme en témoignent de nombreuses études récentes ( voir [Alsheikh-Ali *et al*. 2011](https://doi.org/10.1371%2Fjournal.pone.0024357) et [Nekrutenko & Taylor, 2012](https://doi.org/10.1038%2Fnrg3305) par exemple). [ReProVirtuFlow](https://www.madics.fr/actions/actions-en-cours/reprovirtuflow) est une action du [GDR MaDICS](https://www.madics.fr) qui vise à faire un état des lieux complet sur les approches existantes dans ce domaine en considérant en priorité comme éléments de solution: (i) les workflows scientifiques (au sens large), (ii) la provenance des données, (iii) les environnements de calcul virtualisés (machines virtuelles ou conteneurs). Notre consortium regroupe des experts en bases de données, algorithmique, programmation, et environnements virtuels et des responsables de plateformes et centres de collecte de données scientifiques (CNRS INSB pour la biologie et CNRS IN2P3 pour la physique).
 
 # Les ReproHackathons
-Dans le cadre de notre action, nous lançons l'organisation d'une série de ReproHackathons visant à tester les capacités des systèmes de workflows disponibles à reproduire une expérience scientifique. 
+Dans le cadre de notre action, nous lançons l'organisation d'une série de ReproHackathons visant à tester les capacités des systèmes de workflows disponibles à reproduire une expérience scientifique.
 
-Chaque ReproHackathon fournira aux participants : 
+Chaque ReproHackathon fournira aux participants :
 * un accès au [Cloud de l'Institut Francais de Bioinformatique](http://www.france-bioinformatique.fr/fr/cloud),
 * des cas d’utilisation fixés issus de publications scientifiques : pour chaque cas d’utilisation : un pipeline d'analyse et un jeu de données d'entrée, le défi sera de reproduire les résultats de la publication choisie.
 
@@ -17,7 +17,7 @@ Les participants pourront se regrouper en équipes et choisir :
 
 * [Première édition](hackathon_1_programme.md), 1-2 juin 2017, IFB-core, Campus CNRS, Gif-sur-Yvette
 * [Deuxième édition](hackathon_2_programme.md), 9-10 juillet 2018, LBBE-PRABI, Campus LyonTech-la Doua, Lyon
-* Troisième édition, 25-26 novembre 2019, Montpellier
+* [Troisième édition](hackathon_3_programme.md), 25-26 novembre 2019, Montpellier
 
 ## Comité d'organisation
 


### PR DESCRIPTION
Update the web pages to announce the ReproHackathon 3 on high-throughput phenotyping in Montpellier, Cirad.